### PR TITLE
シフト提出期限外のシフト編集制限実装

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -64,6 +64,11 @@ class ShiftsController < ApplicationController
                shift.from_staff_msg == before_from_staff_msg
           @total_change_count = @total_change_count.to_i + 1
         end
+        # シフト提出期限外は、シフト追加申請のみ可・提出済シフトの変更は不可
+        if !within_submission_deadline? && before_start_time.present?
+          raise ActiveRecord::RecordInvalid unless before_start_time == shift.request_start_time && before_end_time == shift.request_end_time &&
+                              shift.from_staff_msg == before_from_staff_msg
+        end
       end
     end
     flash[:success] = "次回のシフトを申請しました。" if @total_change_count.to_i > 0

--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -109,4 +109,9 @@ module ShiftsHelper
     current_first_day = "#{Date.current.year}-#{Date.current.month}-16".to_date
     return true unless @first_day == current_first_day
   end
+  
+  # 現在がシフト提出期限内かか確認
+  def within_submission_deadline?
+    Date.current.day == [1..8] || Date.current.day == [16..23] ? true : false
+  end
 end

--- a/app/views/shifts/apply_next_shifts.html.erb
+++ b/app/views/shifts/apply_next_shifts.html.erb
@@ -60,8 +60,6 @@
               </td>
               <td>
                 <%= shift.text_field :from_staff_msg, class: "form-control" %>
-                <%= shift.hidden_field :start_time, value: "" %>
-                <%= shift.hidden_field :end_time, value: "" %>
                 <%= shift.hidden_field :apply_day, value: Date.current %>
               </td>
             </tr>


### PR DESCRIPTION
シフト提出期限外では、新規希望シフト提出のみ可能。
提出済希望シフトの編集不可。