### PR TITLE
従業員が管理者画面を開けないようにする

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -11,10 +11,6 @@
   
   <div class="row skill-check-area">
     <div class="col-xs-6 skill-check-item">
-      <%= f.label :admin, class: "label-#{yield(:class_text)}" %>
-      <%= f.check_box :admin, class: "skill-check" %>
-    </div>
-    <div class="col-xs-6 skill-check-item">
       <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
       <%= f.check_box :kitchen, class: "skill-check" %>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,24 +17,40 @@
       <h3 class="skill-check-title">スキルチェック</h3>
       
       <div class="row skill-check-area">
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :admin, class: "label-#{yield(:class_text)}" %>
-          <%= f.check_box :admin, class: "skill-check" %>
+        <% if current_user.admin == true %>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :admin, class: "label-#{yield(:class_text)}" %>
+            <%= f.check_box :admin, class: "skill-check", disabled: "true" %>
+          </div>
+        <% end %>
+        <% if current_user.admin == true %>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
+            <%= f.check_box :kitchen, class: "skill-check", disabled: "true" %>
+          </div>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :hole, class: "label-#{yield(:class_text)}" %>
+            <%= f.check_box :hole, class: "skill-check", disabled: "true" %>
+          </div>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :wash, class: "label-#{yield(:class_form_withtext)}" %>&emsp;
+            <%= f.check_box :wash, class: "skill-check", disabled: "true" %>
+          </div>
+        <% else %>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
+            <%= f.check_box :kitchen, class: "skill-check" %>
+          </div>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :hole, class: "label-#{yield(:class_text)}" %>
+            <%= f.check_box :hole, class: "skill-check" %>
+          </div>
+          <div class="col-xs-6 skill-check-item">
+            <%= f.label :wash, class: "label-#{yield(:class_form_withtext)}" %>&emsp;
+            <%= f.check_box :wash, class: "skill-check" %>
+          </div>
+        <% end %>
         </div>
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
-          <%= f.check_box :kitchen, class: "skill-check" %>
-        </div>
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :hole, class: "label-#{yield(:class_text)}" %>
-          <%= f.check_box :hole, class: "skill-check" %>
-        </div>
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :wash, class: "label-#{yield(:class_form_withtext)}" %>&emsp;
-          <%= f.check_box :wash, class: "skill-check" %>
-        </div>
-      </div>
-    
       <%= f.label :password, class: "label-#{yield(:class_text)}" %>
       <%= f.password_field :password, class: "form-control" %>
     


### PR DESCRIPTION
・従業員ログイン時、スタッフ情報の更新画面から、スキルチェック欄の管理者のチェックボックスを選択できないようにする

・ユーザー登録画面から、スキルチェック欄の管理者のチェックボックスを選択できないようにする（管理者を増やしたい場合、管理者画面のスタッフ一覧画面から「スタッフ情報編集」を押下し、押下後のモーダル画面のスキルチェック欄から従業員に管理者権限を付与する）

・管理者ログイン時、スタッフ情報の更新画面から、スキルチェック欄は管理者のチェックボックスにチェックが入った状態のまま変更できないようにし、キッチン、ホール、洗い場のチェックボックスを選択できないようにする（管理者が誤ってスタッフ情報の更新画面でキッチン、ホール、洗い場のいずれかのチェックボックスを選択して更新ボタンを押してしまった後、自分を管理者に戻す方法が無くなってしまう為）