### PR TITLE
管理者チェックボックスを削除

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -12,11 +12,6 @@
 }
 
 /* ユーザーフォーム */
-
-.label-signup {
-  margin-top: 5px;
-}
-
 .btn-signup {
   margin-top: 10px;
 }
@@ -36,13 +31,12 @@
   text-align: center;
 }
 
-input[type=checkbox].skill-check {
-  margin-left: 10px;
-  transform: scale(1.5);
+.skill-check-kitchen {
+  margin-left: -20px;
 }
 
-.label-user--edit {
-  margin-top: 5px;
+input[type=checkbox].skill-check {
+  transform: scale(1.5);
 }
 
 .btn-user--edit {
@@ -63,10 +57,6 @@ input[type=checkbox].skill-check {
 }
 
 /* ユーザー編集ページ */
-.label-user-info {
-  margin-top: 5px;
-}
-
 .btn-user-info {
   margin-top: 10px;
 }

--- a/app/views/users/_edit_user_info.html.erb
+++ b/app/views/users/_edit_user_info.html.erb
@@ -21,20 +21,16 @@
 　　        <h3 class="skill-check-title">スキルチェック</h3>
   
             <div class="row skill-check-area">
-              <div class="col-xs-6 skill-check-item">
-                <%= f.label :admin, class: "label-#{yield(:class_text)}" %>
-                <%= f.check_box :admin, class: "skill-check" %>
-              </div>
-              <div class="col-xs-6 skill-check-item">
-                <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
+              <div class="col-xs-4 skill-check-item">
+                <%= f.label :kitchen, class: "skill-check-kitchen" %>
                 <%= f.check_box :kitchen, class: "skill-check" %>
               </div>
-              <div class="col-xs-6 skill-check-item">
-                <%= f.label :hole, class: "label-#{yield(:class_text)}" %>
+              <div class="col-xs-4 skill-check-item">
+                <%= f.label :hole %>
                 <%= f.check_box :hole, class: "skill-check" %>
               </div>
-              <div class="col-xs-6 skill-check-item">
-                <%= f.label :wash, class: "label-#{yield(:class_form_withtext)}" %>&emsp;
+              <div class="col-xs-4 skill-check-item">
+                <%= f.label :wash %>
                 <%= f.check_box :wash, class: "skill-check" %>
               </div>
             </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -10,20 +10,16 @@
   <h3 class="skill-check-title">スキルチェック</h3>
   
   <div class="row skill-check-area">
-    <div class="col-xs-6 skill-check-item">
-      <%= f.label :admin, class: "label-#{yield(:class_text)}" %>
-      <%= f.check_box :admin, class: "skill-check" %>
-    </div>
-    <div class="col-xs-6 skill-check-item">
-      <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
+    <div class="col-xs-4 skill-check-item">
+      <%= f.label :kitchen, class: "skill-check-kitchen" %>
       <%= f.check_box :kitchen, class: "skill-check" %>
     </div>
-    <div class="col-xs-6 skill-check-item">
-      <%= f.label :hole, class: "label-#{yield(:class_text)}" %>
+    <div class="col-xs-4 skill-check-item">
+      <%= f.label :hole %>
       <%= f.check_box :hole, class: "skill-check" %>
     </div>
-    <div class="col-xs-6 skill-check-item">
-      <%= f.label :wash, class: "label-#{yield(:class_form_withtext)}" %>&emsp;
+    <div class="col-xs-4 skill-check-item">
+      <%= f.label :wash %>
       <%= f.check_box :wash, class: "skill-check" %>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -14,26 +14,24 @@
       <%= f.label :email, class: "label-#{yield(:class_text)}" %>
       <%= f.email_field :email, class: "form-control" %>
       
-      <h3 class="skill-check-title">スキルチェック</h3>
-      
-      <div class="row skill-check-area">
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :admin, class: "label-#{yield(:class_text)}" %>
-          <%= f.check_box :admin, class: "skill-check" %>
+      <% if current_user.admin == false %>
+        <h3 class="skill-check-title">スキルチェック</h3>
+
+        <div class="row skill-check-area">
+          <div class="col-xs-4 skill-check-item">
+            <%= f.label :kitchen, class: "skill-check-kitchen" %>
+            <%= f.check_box :kitchen, class: "skill-check" %>
+          </div>
+          <div class="col-xs-4 skill-check-item">
+            <%= f.label :hole %>
+            <%= f.check_box :hole, class: "skill-check" %>
+          </div>
+          <div class="col-xs-4 skill-check-item">
+            <%= f.label :wash %>
+            <%= f.check_box :wash, class: "skill-check" %>
+          </div>
         </div>
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :kitchen, class: "label-#{yield(:class_text)}" %>
-          <%= f.check_box :kitchen, class: "skill-check" %>
-        </div>
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :hole, class: "label-#{yield(:class_text)}" %>
-          <%= f.check_box :hole, class: "skill-check" %>
-        </div>
-        <div class="col-xs-6 skill-check-item">
-          <%= f.label :wash, class: "label-#{yield(:class_form_withtext)}" %>&emsp;
-          <%= f.check_box :wash, class: "skill-check" %>
-        </div>
-      </div>
+      <% end %>
     
       <%= f.label :password, class: "label-#{yield(:class_text)}" %>
       <%= f.password_field :password, class: "form-control" %>


### PR DESCRIPTION
実装内容：
１、ユーザー登録画面から、管理者チェックボックスを削除
２、従業員ログイン時のスタッフ情報の更新画面から、管理者チェックボックスを削除
３、管理者ログイン時のスタッフ情報の更新画面から、スキルチェック欄を削除
４、管理者ログイン時のスタッフ情報編集画面から、管理者チェックボックスを削除