### PR TITLE
シフト追加モーダル、シフト編集モーダル等のポジションの表記の修正

### DIFF
--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -77,9 +77,9 @@ module ShiftsHelper
     elsif user.kitchen == false && user.hole == true && user.wash == true
       return "ホール"
     elsif user.kitchen == true && user.hole == true && user.wash == false
-      return "キッチン/ホール"
+      return "キッチン"
     elsif user.kitchen == true && user.hole == true && user.wash == true
-      return "キッチン/ホール"
+      return "キッチン"
     elsif user.kitchen == false && user.hole == false && user.wash == true
       return "洗い場"
     else

--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -68,14 +68,22 @@ module ShiftsHelper
   
   # ユーザーの、可能なポジションを表示
   def put_position(user)
-    if user.kitchen == true && user.hole == false
+    if user.kitchen == true && user.hole == false && user.wash == false
       return "キッチン"
-    elsif user.kitchen == false && user.hole == true
+    elsif user.kitchen == true && user.hole == false && user.wash == true
+      return "キッチン"
+    elsif user.kitchen == false && user.hole == true && user.wash == false
       return "ホール"
-    elsif user.kitchen == true && user.hole == true
+    elsif user.kitchen == false && user.hole == true && user.wash == true
+      return "ホール"
+    elsif user.kitchen == true && user.hole == true && user.wash == false
       return "キッチン/ホール"
-    else
+    elsif user.kitchen == true && user.hole == true && user.wash == true
+      return "キッチン/ホール"
+    elsif user.kitchen == false && user.hole == false && user.wash == true
       return "洗い場"
+    else
+      return "未登録"
     end
   end
   

--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -68,11 +68,11 @@ module ShiftsHelper
   
   # ユーザーの、可能なポジションを表示
   def put_position(user)
-    if user.kitchen = true && user.hole = false
+    if user.kitchen == true && user.hole == false
       return "キッチン"
-    elsif user.kitchen = false && user.hole = true
+    elsif user.kitchen == false && user.hole == true
       return "ホール"
-    elsif user.kitchen = true && user.hole = true
+    elsif user.kitchen == true && user.hole == true
       return "キッチン/ホール"
     else
       return "洗い場"


### PR DESCRIPTION
下記のポジション列の値が、正しく表示されるようにしました。
例えば、管理者でログインして、「現在のシフト」ボタン押下後の画面で、ポジション列が「洗い場」の従業員が、下記画面のポジション列で「キッチン/ホール」という表記になっていたので、「洗い場」と表記されるようにしました。
・シフト編集モーダルのポジション列
・シフト追加モーダルのポジション列
・ヘッダーバーの「シフト管理」ボタン押下時の「日毎に作成」、「スタッフ毎に作成」の横の「検索」ボタン押下時の申請中シフト一覧画面のポジション列